### PR TITLE
fixed multibyte char error

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -104,7 +104,7 @@ chr <- function(x) { rawToChar(as.raw(x)) }
 substitute_regex <- function(data, pattern, fun, ...) {
   match <- gregexpr(pattern, ..., data)
   regmatches(data, match) <- lapply(regmatches(data, match),
-                                   function(x) { if(length(x) > 0) { vapply(x, function(xx) fun(xx), character(1)) } else { x } })
+                                   function(x) { if(length(x) > 0) { vapply(x, function(xx) paste0(fun(xx), collapse=""), character(1)) } else { x } })
   data
 }
 


### PR DESCRIPTION
If mail body contains multibyte character like chinese, length(fun(xx)) here will great than 1, and vapply force output length = 1
therefore throws an error.

collapsing those multibyte result together solves the problem.